### PR TITLE
Dont supply port kwarg to requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
 
 # format Python code with black
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
     - id: black
       #      language_version: python3.7
@@ -29,7 +29,7 @@ repos:
 
 # static type checking with mypy
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.790
   hooks:
   - id: mypy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 
 ## [Unreleased]
+- fix: Don't supply `port` from kwargs to requests in `util.proxy_http_request`
 
 ## [0.1.8]
 - change: use loadtest app helm chart 0.2.0

--- a/examples/test_http_testing_apps.py
+++ b/examples/test_http_testing_apps.py
@@ -8,7 +8,7 @@ from pytest_helm_charts.utils import wait_for_deployments_to_run, proxy_http_get
 def test_stormforger_load_app_creation(
     kube_cluster: Cluster, stormforger_load_app_factory: StormforgerLoadAppFactoryFunc
 ) -> None:
-    """ This test deploys stormforger_load_app and checks if it response to basic requests.
+    """This test deploys stormforger_load_app and checks if it response to basic requests.
     To make this example run, you need a ready cluster with Giant Swarm App Platform.
     The easiest way to create it is to run: `kube-app-testing.sh -j`.
     """

--- a/pytest_helm_charts/utils.py
+++ b/pytest_helm_charts/utils.py
@@ -91,7 +91,13 @@ def wait_for_deployments_to_run(
     missing_ok: bool = True,
 ) -> List[Deployment]:
     result = wait_for_namespaced_objects_condition(
-        kube_client, Deployment, deployment_names, deployments_namespace, _deployment_running, timeout_sec, missing_ok,
+        kube_client,
+        Deployment,
+        deployment_names,
+        deployments_namespace,
+        _deployment_running,
+        timeout_sec,
+        missing_ok,
     )
     return result
 

--- a/pytest_helm_charts/utils.py
+++ b/pytest_helm_charts/utils.py
@@ -109,6 +109,7 @@ def proxy_http_request(client: HTTPClient, srv: Service, method, path, **kwargs)
     """
     if "port" in kwargs:
         port = kwargs["port"]
+        del kwargs["port"]
     else:
         port = srv.obj["spec"]["ports"][0]["port"]
     kwargs["url"] = f"services/{srv.name}:{port}/proxy/{path}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,7 @@ pytest_plugins = ["pytester"]
 
 
 class MockCluster(Cluster):
-    """Implementation of [Cluster](Cluster) that uses mock HTTPClient
-    """
+    """Implementation of [Cluster](Cluster) that uses mock HTTPClient"""
 
     def __init__(self, mocker: MockFixture):
         super().__init__()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+import pykube
+from unittest.mock import create_autospec
+
+from pytest_helm_charts.clusters import Cluster
+from pytest_helm_charts.utils import proxy_http_request
+
+
+def test_port_kwargs(kube_cluster: Cluster):
+    mock_service = create_autospec(pykube.Service)
+
+    proxy_http_request(kube_cluster.kube_client, mock_service, "GET", "/", port=8000)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,10 @@ from pytest_helm_charts.utils import proxy_http_request
         # empty input kwargs - default service port should be used
         ({}, {"url": "services/test_service:9090/proxy//", "namespace": "test_namespace", "version": "1"}),
         # override the default port, should be included in url
-        ({"port": 8080}, {"url": "services/test_service:8080/proxy//", "namespace": "test_namespace", "version": "1"},),
+        (
+            {"port": 8080},
+            {"url": "services/test_service:8080/proxy//", "namespace": "test_namespace", "version": "1"},
+        ),
     ],
 )
 def test_port_kwargs(mocker: MockFixture, call_kwargs: Dict[str, Any], expected_request_kwargs: Dict[str, Any]) -> None:
@@ -28,5 +31,5 @@ def test_port_kwargs(mocker: MockFixture, call_kwargs: Dict[str, Any], expected_
 
     request = mock_client.request
     assert request.called
-    assert request.call_args.args == ("GET",)
-    assert request.call_args.kwargs == expected_request_kwargs
+    assert request.call_args_list[0][0] == ("GET",)
+    assert request.call_args_list[0][1] == expected_request_kwargs


### PR DESCRIPTION
This PR fixes an issue where a `port` kwarg to `proxy_http_request` caused the underlying `requests` library to fail.