### PR TITLE
Cleanup and abs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- Remove any reference related to supporting multiple clusters. From now on this project always expects to get
+  a `kube.config` for an already existing cluster.
+
 ## [0.2.1]
 - added: include python 3.9 as a version for test running
 - changed: updated dependencies

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -3,29 +3,23 @@ from pathlib import Path
 
 from _pytest.config.argparsing import Parser
 
+from .fixtures import _existing_cluster_factory  # noqa
+from .fixtures import chart_extra_info  # noqa
 from .fixtures import chart_path  # noqa
 from .fixtures import chart_version  # noqa
-from .fixtures import chart_extra_info  # noqa
-from .fixtures import values_file_path  # noqa
-from .fixtures import kube_config  # noqa
 from .fixtures import cluster_type  # noqa
 from .fixtures import kube_cluster  # noqa
-from .fixtures import _existing_cluster_factory  # noqa
-from .fixtures import _kind_cluster_factory  # noqa
-from .fixtures import _giantswarm_cluster_factory  # noqa
-
-from .giantswarm_app_platform.fixtures import app_factory  # noqa
-from .giantswarm_app_platform.fixtures import app_catalog_factory  # noqa
-
-from .giantswarm_app_platform.apps.http_testing import stormforger_load_app_factory  # noqa
+from .fixtures import kube_config  # noqa
+from .fixtures import values_file_path  # noqa
 from .giantswarm_app_platform.apps.http_testing import gatling_app_factory  # noqa
+from .giantswarm_app_platform.apps.http_testing import stormforger_load_app_factory  # noqa
+from .giantswarm_app_platform.fixtures import app_catalog_factory  # noqa
+from .giantswarm_app_platform.fixtures import app_factory  # noqa
 
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup("helm-charts")
-    group.addoption(
-        "--cluster-type", action="store", default="existing", help="Select cluster type. Supported values: 'existing'."
-    )
+    group.addoption("--cluster-type", action="store", help="Pass information about cluster type being used for tests.")
     group.addoption(
         "--kube-config",
         action="store",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,6 @@ def kube_cluster(
     cluster_type: str,
     session_mocker: MockFixture,
     _existing_cluster_factory: ConfigFactoryFunction,
-    _kind_cluster_factory: ConfigFactoryFunction,
-    _giantswarm_cluster_factory: ConfigFactoryFunction,
 ) -> Cluster:
     cluster = MockCluster(session_mocker)
     cluster.create()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -16,6 +16,6 @@ def run_pytest(testdir: Testdir, mocker: MockFixture, *args) -> RunResult:
         *args,
     )
     # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines(["*Cluster created*", "*Cluster destroyed*"])
+    result.stdout.fnmatch_lines(["*Cluster configured*", "*Cluster released*"])
 
     return result


### PR DESCRIPTION
This PR removes code that doesn't have sense here anymore. `pytest-helm-charts` expects now an external cluster and never cares about creating it.