### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/pytest_helm_charts/giantswarm_app_platform/apps/http_testing.py
+++ b/pytest_helm_charts/giantswarm_app_platform/apps/http_testing.py
@@ -114,7 +114,7 @@ def gatling_app_factory(kube_cluster: Cluster, app_factory: AppFactoryFunc) -> I
             "gatling-app",
             "1.0.2",
             "giantswarm-playground",
-            "https://giantswarm.github.com/giantswarm-playground-catalog/",
+            "https://giantswarm.github.io/giantswarm-playground-catalog/",
             namespace,
             config_values,
         )


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898