### PR TITLE
Fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- fix: `wait_for_deployments_to_run` needs to check for `availablePods` as well
+- added: `namespace_factory` fixture you can use to create test time only namespaces
+- change: `app_factory` takes now one more kwarg `deployment_namespace`, which configures
+  the target deployment namespace for the created App CR; in other words, the `namespace` where the App
+  CR is created can be now different than the `deployment_namespace` where app's components are deployed
+- change: if the namespace passed as `namespace` argument to `app_factory` doesn't exist, it is automatically
+  created using the new `namespace_factory` fixture
+
 ## [0.4.1]
 
 - fix: work-around a bug in depended lib that was making `wait_for_deployments_to_run` fail
-- fix: `wait_for_deployments_to_run` needs to check for `availablePods` as well
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 ## [0.4.1]
 
 - fix: work-around a bug in depended lib that was making `wait_for_deployments_to_run` fail
+- fix: `wait_for_deployments_to_run` needs to check for `availablePods` as well
 
 ## [0.4.0]
 

--- a/pytest_helm_charts/fixtures.py
+++ b/pytest_helm_charts/fixtures.py
@@ -124,13 +124,7 @@ def namespace_factory(kube_cluster: Cluster) -> Iterable[NamespaceFactoryFunc]:
 
 
 @pytest.fixture(scope="module")
-def random_namespace(kube_cluster: Cluster) -> pykube.Namespace:
+def random_namespace(namespace_factory: NamespaceFactoryFunc) -> pykube.Namespace:
     """Create and return a random kubernetes namespace that will be deleted at the end of test run."""
     name = f"pytest-{''.join(random.choices(string.ascii_lowercase, k=5))}"
-    ns = ensure_namespace_exists(kube_cluster.kube_client, name)
-    logger.info(f"Ensured the namespace '{name}'.")
-
-    yield ns
-
-    ns.delete()
-    logger.info(f"Deleted the namespace '{name}'.")
+    return namespace_factory(name)

--- a/pytest_helm_charts/fixtures.py
+++ b/pytest_helm_charts/fixtures.py
@@ -3,7 +3,7 @@ import logging
 import random
 import string
 import sys
-from typing import Callable, Iterable, Dict
+from typing import Callable, Iterable, Dict, List
 
 import pykube
 import pytest
@@ -98,11 +98,37 @@ def kube_cluster(
         logger.error(f"Error of type {exc[0]} when releasing cluster. Value: {exc[1]}\nStacktrace:\n{exc[2]}")
 
 
+NamespaceFactoryFunc = Callable[[str], pykube.Namespace]
+
+
+@pytest.fixture(scope="module")
+def namespace_factory(kube_cluster: Cluster) -> Iterable[NamespaceFactoryFunc]:
+    """Return a new namespace that is deleted once the fixture is disposed."""
+    created_namespaces: List[pykube.Namespace] = []
+
+    def _namespace_factory(name: str) -> pykube.Namespace:
+        for namespace in created_namespaces:
+            if namespace.metadata["name"] == name:
+                return namespace
+
+        ns = ensure_namespace_exists(kube_cluster.kube_client, name)
+        logger.info(f"Ensured the namespace '{name}'.")
+        created_namespaces.append(ns)
+        return ns
+
+    yield _namespace_factory
+
+    for created_ns in created_namespaces:
+        created_ns.delete()
+        logger.info(f"Deleted the namespace '{created_ns.name}'.")
+
+
 @pytest.fixture(scope="module")
 def random_namespace(kube_cluster: Cluster) -> pykube.Namespace:
     """Create and return a random kubernetes namespace that will be deleted at the end of test run."""
     name = f"pytest-{''.join(random.choices(string.ascii_lowercase, k=5))}"
     ns = ensure_namespace_exists(kube_cluster.kube_client, name)
+    logger.info(f"Ensured the namespace '{name}'.")
 
     yield ns
 

--- a/pytest_helm_charts/giantswarm_app_platform/fixtures.py
+++ b/pytest_helm_charts/giantswarm_app_platform/fixtures.py
@@ -5,6 +5,7 @@ import pytest
 from .app import ConfiguredApp, AppFactoryFunc, app_factory_func
 from .app_catalog import AppCatalogFactoryFunc, AppCatalogCR, app_catalog_factory_func
 from ..clusters import Cluster
+from ..fixtures import NamespaceFactoryFunc
 
 
 @pytest.fixture(scope="module")
@@ -21,12 +22,14 @@ def app_catalog_factory(kube_cluster: Cluster) -> Iterable[AppCatalogFactoryFunc
 
 
 @pytest.fixture(scope="module")
-def app_factory(kube_cluster: Cluster, app_catalog_factory: AppCatalogFactoryFunc) -> Iterable[AppFactoryFunc]:
+def app_factory(
+    kube_cluster: Cluster, app_catalog_factory: AppCatalogFactoryFunc, namespace_factory: NamespaceFactoryFunc
+) -> Iterable[AppFactoryFunc]:
     """Returns a factory function which can be used to install an app using App CR"""
 
     created_apps: List[ConfiguredApp] = []
 
-    yield app_factory_func(kube_cluster.kube_client, app_catalog_factory, created_apps)
+    yield app_factory_func(kube_cluster.kube_client, app_catalog_factory, namespace_factory, created_apps)
 
     for created in created_apps:
         created.app.delete()

--- a/pytest_helm_charts/giantswarm_app_platform/fixtures.py
+++ b/pytest_helm_charts/giantswarm_app_platform/fixtures.py
@@ -4,7 +4,6 @@ import pytest
 
 from .app import ConfiguredApp, AppFactoryFunc, app_factory_func
 from .app_catalog import AppCatalogFactoryFunc, AppCatalogCR, app_catalog_factory_func
-from .custom_resources import AppCR
 from ..clusters import Cluster
 
 
@@ -36,32 +35,10 @@ def app_factory(kube_cluster: Cluster, app_catalog_factory: AppCatalogFactoryFun
         # TODO: wait until finalizer is gone
 
 
-@pytest.fixture(scope="module")
-def kube_cluster_with_app_platform(
-    kube_cluster: Cluster, app_catalog_factory: AppCatalogFactoryFunc
-) -> Iterable[Cluster]:
-    """Get a ready cluster based on '--cluster-type' command line argument. Additionally,
-    preconfigure the cluster with Giant Swarm's Application Platform, including:
-    - app-operator
-    - chart-operator
-    - chartmuseum (for storing custom build time charts)
-    - AppCatalog Custom Resource configured for the chartmuseum."""
-    # FIXME: implement
-    # TODO:
-    # - deploy app-operator
-    # - deploy chartmuseum
-    # - create new AppCatalog CR with app_catalog_factory to register chartmuseum as catalog
-    raise NotImplementedError
-    # yield kube_cluster
-    # TODO:
-    # - destroy app-operator
-    # - destroy chartmuseum
-
-
-@pytest.fixture(scope="module")
-def my_chart() -> AppCR:
-    """Returns AppCR that can be used to deploy the chart under test using the App Platform
-    tools. The App resource is not yet deployed to the cluster. You need to call create()
-    and delete() to manage its deployment"""
-    # FIXME: implement
-    raise NotImplementedError
+# @pytest.fixture(scope="module")
+# def my_chart() -> AppCR:
+#     """Returns AppCR that can be used to deploy the chart under test using the App Platform
+#     tools. The App resource is not yet deployed to the cluster. You need to call create()
+#     and delete() to manage its deployment"""
+#     # FIXME: implement
+#     raise NotImplementedError

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -9,6 +9,7 @@ from .fixtures import chart_path  # noqa
 from .fixtures import chart_version  # noqa
 from .fixtures import cluster_type  # noqa
 from .fixtures import kube_cluster  # noqa
+from .fixtures import namespace_factory  # noqa
 from .fixtures import random_namespace  # noqa
 from .fixtures import kube_config  # noqa
 from .fixtures import values_file_path  # noqa

--- a/pytest_helm_charts/utils.py
+++ b/pytest_helm_charts/utils.py
@@ -77,10 +77,12 @@ def wait_for_jobs_to_complete(
 def _deployment_running(deploy: Deployment) -> bool:
     complete = (
         "status" in deploy.obj
+        and "availableReplicas" in deploy.obj["status"]
         and "observedGeneration" in deploy.obj["status"]
         and "updatedReplicas" in deploy.obj["status"]
         and int(deploy.obj["status"]["observedGeneration"]) >= int(deploy.obj["metadata"]["generation"])
         and deploy.replicas == int(deploy.obj["status"]["updatedReplicas"])
+        and deploy.replicas == int(deploy.obj["status"]["availableReplicas"])
     )
     return complete
 


### PR DESCRIPTION
- fix: `wait_for_deployments_to_run` needs to check for `availablePods` as well
- added: `namespace_factory` fixture you can use to create test time only namespaces
- change: `app_factory` takes now one more kwarg `deployment_namespace`, which configures
  the target deployment namespace for the created App CR; in other words, the `namespace` where the App
  CR is created can be now different than the `deployment_namespace` where app's components are deployed
- change: if the namespace passed as `namespace` argument to `app_factory` doesn't exist, it is automatically
  created using the new `namespace_factory` fixture
