### PR TITLE
Add function fixtures scope for kubernetes fixtures

### DIFF
--- a/pytest_helm_charts/api/fixtures.py
+++ b/pytest_helm_charts/api/fixtures.py
@@ -20,7 +20,7 @@ class NamespaceFactoryFunc(Protocol):
 
 @pytest.fixture(scope="module")
 def namespace_factory(kube_cluster: Cluster) -> Iterable[NamespaceFactoryFunc]:
-    """Return a new namespace that is deleted once the fixture is disposed."""
+    """Return a new namespace that is deleted once the fixture is disposed. Fixture's scope is 'module'."""
     created_namespaces: List[pykube.Namespace] = []
 
     def _namespace_factory(
@@ -44,7 +44,8 @@ def namespace_factory(kube_cluster: Cluster) -> Iterable[NamespaceFactoryFunc]:
 
 @pytest.fixture(scope="module")
 def random_namespace(namespace_factory: NamespaceFactoryFunc) -> pykube.Namespace:
-    """Create and return a random kubernetes namespace that will be deleted at the end of test run."""
+    """Create and return a random kubernetes namespace that will be deleted at the end of test run.
+    Fixture's scope is 'module'."""
     name = (
         f"pytest-{''.join(random.choices(string.ascii_lowercase, k=5))}"  # nosec B311 - this is non-cryptographic use
     )

--- a/pytest_helm_charts/giantswarm_app_platform/apps/http_testing.py
+++ b/pytest_helm_charts/giantswarm_app_platform/apps/http_testing.py
@@ -23,7 +23,7 @@ class StormforgerLoadAppFactoryFunc(Protocol):
 
 @pytest.fixture(scope="module")
 def stormforger_load_app_factory(app_factory: AppFactoryFunc) -> StormforgerLoadAppFactoryFunc:
-    """A factory fixture to return a function that can produce Stromforger Load App instances.
+    """A factory fixture to return a function that can produce Stromforger Load App instances. Fixture's scope is 'module'..
 
     Args:
         app_factory: auto-injected [app_factory](..app.app_factory) fixture.
@@ -100,7 +100,7 @@ class GatlingAppFactoryFunc(Protocol):
 @pytest.fixture(scope="module")
 def gatling_app_factory(kube_cluster: Cluster, app_factory: AppFactoryFunc) -> Iterable[GatlingAppFactoryFunc]:
     """A factory fixture to return a function that can produce Gatling instances. Gatling is a HTTP
-    performance testing tool.
+    performance testing tool. Fixture's scope is 'module'..
 
     Args:
         app_factory: auto-injected [app_factory](..app.app_factory) fixture.

--- a/pytest_helm_charts/giantswarm_app_platform/fixtures.py
+++ b/pytest_helm_charts/giantswarm_app_platform/fixtures.py
@@ -29,7 +29,7 @@ from pytest_helm_charts.utils import object_factory_helper, delete_and_wait_for_
 @pytest.fixture(scope="module")
 def app_catalog_factory(kube_cluster: Cluster) -> Iterable[AppCatalogFactoryFunc]:
     """Return a factory object, that can be used to configure new AppCatalog CRs
-    for the 'app-operator' running in the cluster"""
+    for the 'app-operator' running in the cluster. Fixture's scope is 'module'."""
     for o in object_factory_helper(kube_cluster, app_catalog_factory_func, AppCatalogCR):
         yield o
 
@@ -37,7 +37,7 @@ def app_catalog_factory(kube_cluster: Cluster) -> Iterable[AppCatalogFactoryFunc
 @pytest.fixture(scope="module")
 def catalog_factory(kube_cluster: Cluster, namespace_factory: NamespaceFactoryFunc) -> Iterable[CatalogFactoryFunc]:
     """Return a factory object, that can be used to configure new Catalog CRs
-    for the 'app-operator' running in the cluster"""
+    for the 'app-operator' running in the cluster. Fixture's scope is 'module'."""
     created_objects: List[CatalogCR] = []
 
     yield catalog_factory_func(kube_cluster.kube_client, created_objects, namespace_factory)
@@ -49,7 +49,7 @@ def catalog_factory(kube_cluster: Cluster, namespace_factory: NamespaceFactoryFu
 def app_factory(
     kube_cluster: Cluster, catalog_factory: CatalogFactoryFunc, namespace_factory: NamespaceFactoryFunc
 ) -> Iterable[AppFactoryFunc]:
-    """Returns a factory function which can be used to install an app using App CR"""
+    """Returns a factory function which can be used to install an app using App CR. Fixture's scope is 'module'."""
 
     created_apps: List[ConfiguredApp] = []
 

--- a/pytest_helm_charts/giantswarm_app_platform/fixtures.py
+++ b/pytest_helm_charts/giantswarm_app_platform/fixtures.py
@@ -30,14 +30,28 @@ from pytest_helm_charts.utils import object_factory_helper, delete_and_wait_for_
 def app_catalog_factory(kube_cluster: Cluster) -> Iterable[AppCatalogFactoryFunc]:
     """Return a factory object, that can be used to configure new AppCatalog CRs
     for the 'app-operator' running in the cluster. Fixture's scope is 'module'."""
-    for o in object_factory_helper(kube_cluster, app_catalog_factory_func, AppCatalogCR):
-        yield o
+    yield from object_factory_helper(kube_cluster, app_catalog_factory_func, AppCatalogCR)
+
+
+@pytest.fixture(scope="function")
+def catalog_factory_function_scope(
+    kube_cluster: Cluster, namespace_factory: NamespaceFactoryFunc
+) -> Iterable[CatalogFactoryFunc]:
+    """Return a factory object, that can be used to configure new Catalog CRs
+    for the 'app-operator' running in the cluster. Fixture's scope is 'function'."""
+    yield from _catalog_factory_impl(kube_cluster, namespace_factory)
 
 
 @pytest.fixture(scope="module")
 def catalog_factory(kube_cluster: Cluster, namespace_factory: NamespaceFactoryFunc) -> Iterable[CatalogFactoryFunc]:
     """Return a factory object, that can be used to configure new Catalog CRs
     for the 'app-operator' running in the cluster. Fixture's scope is 'module'."""
+    yield from _catalog_factory_impl(kube_cluster, namespace_factory)
+
+
+def _catalog_factory_impl(
+    kube_cluster: Cluster, namespace_factory: NamespaceFactoryFunc
+) -> Iterable[CatalogFactoryFunc]:
     created_objects: List[CatalogCR] = []
 
     yield catalog_factory_func(kube_cluster.kube_client, created_objects, namespace_factory)
@@ -50,6 +64,21 @@ def app_factory(
     kube_cluster: Cluster, catalog_factory: CatalogFactoryFunc, namespace_factory: NamespaceFactoryFunc
 ) -> Iterable[AppFactoryFunc]:
     """Returns a factory function which can be used to install an app using App CR. Fixture's scope is 'module'."""
+    yield from _app_factory_impl(kube_cluster, catalog_factory, namespace_factory)
+
+
+@pytest.fixture(scope="function")
+def app_factory_function_scope(
+    kube_cluster: Cluster, catalog_factory: CatalogFactoryFunc, namespace_factory: NamespaceFactoryFunc
+) -> Iterable[AppFactoryFunc]:
+    """Returns a factory function which can be used to install an app using App CR. Fixture's scope is 'module'."""
+    yield from _app_factory_impl(kube_cluster, catalog_factory, namespace_factory)
+
+
+def _app_factory_impl(
+    kube_cluster: Cluster, catalog_factory: CatalogFactoryFunc, namespace_factory: NamespaceFactoryFunc
+) -> Iterable[AppFactoryFunc]:
+    """Returns a factory function which can be used to install an app using App CR."""
 
     created_apps: List[ConfiguredApp] = []
 


### PR DESCRIPTION
So far, the lib offered only module (whole python file) scoped fixtures. This PR introduces function scoped counterparts. This means, that the test automation creates a requested object at the beginning of a single test and cleans it up at the end.

Closes: https://github.com/giantswarm/giantswarm/issues/20208