### PR TITLE
Switch from cmd line args to env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 - changed:
   - `_flux_cr_ready` made public by renaming to `flux_cr_ready`
-  - Breaking change: test information data is now not being input by the (partially mandatory) command line parameters,
-    but by environment variables. This allows `pytest-helm-charts` to be easily used without the `app-test-suite`
+  - Test information data is now primarily being input by (partially mandatory) environment variables.
+    Majority of old command line parameters should still work, but environment variables usage is encouraged.
+    This allows `pytest-helm-charts` to be easily used without the `app-test-suite`
     project, which was enforcing the cmd line parameters before. The following env vars are recognised and used in
     fixtures (when requested):
     - "KUBECONFIG" - (mandatory) a path to kube config file used to connect to a k8s cluster
@@ -15,8 +16,6 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
     - "ATS_CHART_VERSION" - version of the chart being tested (if a chart is tested)
     - "ATS_CLUSTER_TYPE" - (informative only) type of the cluster used for testing
     - "ATS_CLUSTER_VERSION" - (informative only) k8s version of the cluster used for testing
-    - "ATS_TEST_TYPE" - test type being requested
-    - "ATS_TEST_DIR" - directory from which tests are run
     - "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test
       (if a chart is tested)
     - "ATS_EXTRA_*" - any such arbitrary variable value will be extracted and included in the `test_extra_info` fixture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
     - "ATS_CLUSTER_VERSION" - (informative only) k8s version of the cluster used for testing
     - "ATS_TEST_TYPE" - test type being requested
     - "ATS_TEST_DIR" - directory from which tests are run
-    - "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test 
+    - "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test
       (if a chart is tested)
     - "ATS_EXTRA_*" - any such arbitrary variable value will be extracted and included in the `test_extra_info` fixture
   - `chart_extra_info` fixture was removed, as the more general `test_extra_info` is available
-     
+
 - updated:
   - `pytest` upgraded from 6.x series to 7.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 - changed:
   - `_flux_cr_ready` made public by renaming to `flux_cr_ready`
+  - breaking change: test information data is now not being input by the (partially mandatory) command line parameters,
+    but by environment variables; the following env vars are recognised and used in fixtures (when requested):
+    - "KUBECONFIG" - (mandatory) a path to kube config file used to connect to a k8s cluster
+    - "ATS_CHART_PATH" - path to a chart being tested (if a chart is tested)
+    - "ATS_CHART_VERSION" - version of the chart being tested (if a chart is tested)
+    - "ATS_CLUSTER_TYPE" - (informative only) type of the cluster used for testing
+    - "ATS_CLUSTER_VERSION" - (informative only) k8s version of the cluster used for testing
+    - "ATS_TEST_TYPE" - test type being requested
+    - "ATS_TEST_DIR" - directory from which tests are run
+    - "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test 
+      (if a chart is tested)
+    - "ATS_EXTRA_*" - any such arbitrary variable value will be extracted and included in the `test_extra_info` fixture
+  - `chart_extra_info` fixture was removed, as the more general `test_extra_info` is available
+     
 - updated:
   - `pytest` upgraded from 6.x series to 7.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 - changed:
   - `_flux_cr_ready` made public by renaming to `flux_cr_ready`
-  - breaking change: test information data is now not being input by the (partially mandatory) command line parameters,
-    but by environment variables; the following env vars are recognised and used in fixtures (when requested):
+  - Breaking change: test information data is now not being input by the (partially mandatory) command line parameters,
+    but by environment variables. This allows `pytest-helm-charts` to be easily used without the `app-test-suite`
+    project, which was enforcing the cmd line parameters before. The following env vars are recognised and used in
+    fixtures (when requested):
     - "KUBECONFIG" - (mandatory) a path to kube config file used to connect to a k8s cluster
     - "ATS_CHART_PATH" - path to a chart being tested (if a chart is tested)
     - "ATS_CHART_VERSION" - version of the chart being tested (if a chart is tested)

--- a/README.md
+++ b/README.md
@@ -48,16 +48,15 @@ pip install pytest-helm-charts
 ### Running your tests
 
 When you want to run your tests, you invoke `pytest` as usual, just configuring
-cluster and chart information using environment variables. The following options
-are available:
+cluster and chart information using environment variables or command line options.
+The following options are available as environment variables (start `pytest` with `-h`
+to check corresponding command line options):
 
 - "KUBECONFIG" - (mandatory) a path to kube config file used to connect to a k8s cluster
 - "ATS_CHART_PATH" - path to a chart being tested (if a chart is tested)
 - "ATS_CHART_VERSION" - version of the chart being tested (if a chart is tested)
 - "ATS_CLUSTER_TYPE" - type of the cluster used for testing
 - "ATS_CLUSTER_VERSION" - k8s version of the cluster used for testing
-- "ATS_TEST_TYPE" - test type being requested
-- "ATS_TEST_DIR" - directory from which tests are run
 - "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test
 (if a chart is tested)
 - "ATS_EXTRA_*" - any such arbitrary variable value will be extracted and included in the `test_extra_info` fixture

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It can be also used to test Helm charts deployed using the Open Source
 Most important features:
 
 - provides [pykube-ng](http://pykube.readthedocs.io/) interface to access Kubernetes clusters
-- provides [command line options](#usage) to configure the target cluster to run on
+- provides [environment variables based options](#usage) to configure the target cluster to run on
 - provides fixtures to work with some standard Kubernetes resources as well as some custom ones:
   - [Kubernetes objects](pytest_helm_charts.k8s)
   - [Giant Swarm App Platform objects](pytest_helm_charts.giantswarm_app_platform)
@@ -47,13 +47,24 @@ pip install pytest-helm-charts
 
 ### Running your tests
 
-When you want to run your tests, you invoke `pytest` as usual, just passing additional
-flags on the command line. You can inspect them directly by running `pytest -h` and
-checking the "helm-charts" section.
+When you want to run your tests, you invoke `pytest` as usual, just configuring
+cluster and chart information using environment variables. The following options
+are available:
+
+- "KUBECONFIG" - (mandatory) a path to kube config file used to connect to a k8s cluster
+- "ATS_CHART_PATH" - path to a chart being tested (if a chart is tested)
+- "ATS_CHART_VERSION" - version of the chart being tested (if a chart is tested)
+- "ATS_CLUSTER_TYPE" - type of the cluster used for testing
+- "ATS_CLUSTER_VERSION" - k8s version of the cluster used for testing
+- "ATS_TEST_TYPE" - test type being requested
+- "ATS_TEST_DIR" - directory from which tests are run
+- "ATS_APP_CONFIG_FILE_PATH" - optional path to a `values.yaml` file used to configure a chart under test
+(if a chart is tested)
+- "ATS_EXTRA_*" - any such arbitrary variable value will be extracted and included in the `test_extra_info` fixture
 
 Currently, the only supported cluster type is `external`, which means the cluster is not
 managed by the test suite. You just point the test suite to a `kube.config` file,
-which can be used to connect to the Kubernetes API with `--kube-config` command line
+which can be used to connect to the Kubernetes API with `KUBECONFIG` env variable
 option. For creating development time clusters, we recommend using
 [KinD](https://kind.sigs.k8s.io/).
 

--- a/examples/test_basic_cluster.py
+++ b/examples/test_basic_cluster.py
@@ -23,11 +23,11 @@ def test_api_working(kube_cluster: Cluster) -> None:
     assert len(pykube.Node.objects(kube_cluster.kube_client)) >= 1
 
 
-def test_cluster_info(kube_cluster: Cluster, cluster_type: str, chart_extra_info: Dict[str, str]) -> None:
+def test_cluster_info(kube_cluster: Cluster, cluster_type: str, test_extra_info: Dict[str, str]) -> None:
     """Example shows how you can access additional information about the cluster the tests are running on"""
     logger.info(f"Running on cluster type {cluster_type}")
     key = "external_cluster_type"
-    if key in chart_extra_info:
-        logger.info(f"{key} is {chart_extra_info[key]}")
+    if key in test_extra_info:
+        logger.info(f"{key} is {test_extra_info[key]}")
     assert kube_cluster.kube_client is not None
     assert cluster_type != ""

--- a/pytest_helm_charts/fixtures.py
+++ b/pytest_helm_charts/fixtures.py
@@ -34,25 +34,25 @@ def _load_optional_from_environ(var_name: str) -> str:
 @pytest.fixture(scope="module")
 def chart_path() -> str:
     """Return a path to the chart under test (from command line argument)."""
-    return _load_mandatory_from_environ(CHART_PATH)
+    return _load_optional_from_environ(CHART_PATH)
 
 
 @pytest.fixture(scope="module")
 def chart_version() -> str:
     """Return a value that needs to be used as chart version override (from command line argument)."""
-    return _load_mandatory_from_environ(CHART_VERSION)
+    return _load_optional_from_environ(CHART_VERSION)
 
 
 @pytest.fixture(scope="module")
 def cluster_type() -> str:
     """Return a type of cluster used for testing (from command line argument)."""
-    return _load_mandatory_from_environ(CLUSTER_TYPE)
+    return _load_optional_from_environ(CLUSTER_TYPE)
 
 
 @pytest.fixture(scope="module")
 def cluster_version() -> str:
     """Return a type of cluster used for testing (from command line argument)."""
-    return _load_mandatory_from_environ(CLUSTER_VERSION)
+    return _load_optional_from_environ(CLUSTER_VERSION)
 
 
 @pytest.fixture(scope="module")

--- a/pytest_helm_charts/fixtures.py
+++ b/pytest_helm_charts/fixtures.py
@@ -5,101 +5,113 @@ import sys
 from typing import Iterable, Dict, Mapping
 
 import pytest
+from _pytest.config import Config
 
 from pytest_helm_charts.clusters import ExistingCluster, Cluster
 
 logger = logging.getLogger(__name__)
 
-CHART_PATH = "ATS_CHART_PATH"
-CHART_VERSION = "ATS_CHART_VERSION"
-CLUSTER_TYPE = "ATS_CLUSTER_TYPE"
-CLUSTER_VERSION = "ATS_CLUSTER_VERSION"
-TEST_TYPE = "ATS_TEST_TYPE"
-TEST_DIR = "ATS_TEST_DIR"
-APP_CONFIG_PATH = "ATS_APP_CONFIG_FILE_PATH"
-KUBE_CONFIG = "KUBECONFIG"
-ATS_EXTRA_PREFIX = "ATS_EXTRA_"
+ENV_VAR_CHART_PATH = "ATS_CHART_PATH"
+ENV_VAR_CHART_VERSION = "ATS_CHART_VERSION"
+ENV_VAR_CLUSTER_TYPE = "ATS_CLUSTER_TYPE"
+ENV_VAR_CLUSTER_VERSION = "ATS_CLUSTER_VERSION"
+ENV_VAR_APP_CONFIG_PATH = "ATS_APP_CONFIG_FILE_PATH"
+ENV_VAR_KUBE_CONFIG = "KUBECONFIG"
+ENV_VAR_ATS_EXTRA_PREFIX = "ATS_EXTRA_"
+CMD_VAR_TEST_EXTRA_INFO = "test_extra_info"
 
 
-def _load_mandatory_from_environ(var_name: str) -> str:
-    if var_name in os.environ and len(os.environ[var_name]) > 0:
-        return os.environ[var_name]
-    raise Exception(f"Environment variable '{var_name}' needed by a fixture, but not set.")
+def get_cmd_line_option_name_from_env_var(env_var_name: str) -> str:
+    cmd_name = env_var_name.lower()
+    if cmd_name.startswith("ats_"):
+        cmd_name = cmd_name[4:]
+    return cmd_name
 
 
-def _load_optional_from_environ(var_name: str) -> str:
-    return os.environ[var_name] if var_name in os.environ else ""
+def _load_mandatory_config_option(pytestconfig: Config, env_var_name: str) -> str:
+    cmd_name = get_cmd_line_option_name_from_env_var(env_var_name)
+    if pytestconfig.getoption(cmd_name):
+        return pytestconfig.getoption(cmd_name)
+    if env_var_name in os.environ and len(os.environ[env_var_name]) > 0:
+        return os.environ[env_var_name]
+    raise Exception(
+        f"Environment variable '{env_var_name}' (or relevant cmd line option, see help '-h') needed "
+        "by a fixture, but not set."
+    )
 
 
-@pytest.fixture(scope="module")
-def chart_path() -> str:
-    """Return a path to the chart under test (from command line argument)."""
-    return _load_optional_from_environ(CHART_PATH)
+def _load_optional_config_option(pytestconfig: Config, env_var_name: str) -> str:
+    cmd_name = get_cmd_line_option_name_from_env_var(env_var_name)
+    if pytestconfig.getoption(cmd_name):
+        return pytestconfig.getoption(cmd_name)
+    return os.environ[env_var_name] if env_var_name in os.environ else ""
 
 
-@pytest.fixture(scope="module")
-def chart_version() -> str:
-    """Return a value that needs to be used as chart version override (from command line argument)."""
-    return _load_optional_from_environ(CHART_VERSION)
-
-
-@pytest.fixture(scope="module")
-def cluster_type() -> str:
-    """Return a type of cluster used for testing (from command line argument)."""
-    return _load_optional_from_environ(CLUSTER_TYPE)
-
-
-@pytest.fixture(scope="module")
-def cluster_version() -> str:
-    """Return a type of cluster used for testing (from command line argument)."""
-    return _load_optional_from_environ(CLUSTER_VERSION)
-
-
-@pytest.fixture(scope="module")
-def test_type() -> str:
-    """Return a type of the test requested in the current run."""
-    return _load_optional_from_environ(TEST_TYPE)
-
-
-@pytest.fixture(scope="module")
-def test_dir() -> str:
-    """Return a type of the test requested in the current run."""
-    return _load_optional_from_environ(TEST_TYPE)
-
-
-@pytest.fixture(scope="module")
-def values_file_path() -> str:
-    """Return a path to the yaml file that needs to be used to configure chart under test
-    (from command line argument).
-    """
-    return _load_optional_from_environ(APP_CONFIG_PATH)
-
-
-@pytest.fixture(scope="module")
-def kube_config() -> str:
-    """Return a path to the kube.config file that points to a running cluster with app
-    catalog platform tools already installed."""
-    return _load_mandatory_from_environ(KUBE_CONFIG)
-
-
-def _parse_extra_info(info: str) -> Dict[str, str]:
+def _parse_cmd_opt_extra_info(info: str) -> Dict[str, str]:
     pairs = list(filter(None, info.split(",")))
     res_dict: Dict[str, str] = {}
     for pair in pairs:
         k, v = list(filter(None, pair.split("=")))
-        res_dict[k] = v
+        res_dict[k.lower()] = v
     return res_dict
 
 
 def _filter_extra_info_from_mapping(extra: Mapping[str, str]) -> Dict[str, str]:
-    return {k[len(ATS_EXTRA_PREFIX) :].lower(): v for k, v in extra.items() if k.startswith(ATS_EXTRA_PREFIX)}
+    return {
+        k[len(ENV_VAR_ATS_EXTRA_PREFIX) :].lower(): v
+        for k, v in extra.items()
+        if k.startswith(ENV_VAR_ATS_EXTRA_PREFIX)
+    }
 
 
 @pytest.fixture(scope="module")
-def test_extra_info() -> Dict[str, str]:
-    """Return an optional dict of variable names and values passed to the test using env vars prefixed with
-    'ATS_EXTRA_' env var."""
-    return _filter_extra_info_from_mapping(os.environ)
+def chart_path(pytestconfig: Config) -> str:
+    """Return a path to the chart under test (from command line argument)."""
+    return _load_optional_config_option(pytestconfig, ENV_VAR_CHART_PATH)
+
+
+@pytest.fixture(scope="module")
+def chart_version(pytestconfig: Config) -> str:
+    """Return a value that needs to be used as chart version override (from command line argument)."""
+    return _load_optional_config_option(pytestconfig, ENV_VAR_CHART_VERSION)
+
+
+@pytest.fixture(scope="module")
+def cluster_type(pytestconfig: Config) -> str:
+    """Return a type of cluster used for testing (from command line argument)."""
+    return _load_optional_config_option(pytestconfig, ENV_VAR_CLUSTER_TYPE)
+
+
+@pytest.fixture(scope="module")
+def cluster_version(pytestconfig: Config) -> str:
+    """Return a type of cluster used for testing (from command line argument)."""
+    return _load_optional_config_option(pytestconfig, ENV_VAR_CLUSTER_VERSION)
+
+
+@pytest.fixture(scope="module")
+def values_file_path(pytestconfig: Config) -> str:
+    """Return a path to the yaml file that needs to be used to configure chart under test
+    (from command line argument).
+    """
+    return _load_optional_config_option(pytestconfig, ENV_VAR_APP_CONFIG_PATH)
+
+
+@pytest.fixture(scope="module")
+def kube_config(pytestconfig: Config) -> str:
+    """Return a path to the kube.config file that points to a running cluster with app
+    catalog platform tools already installed."""
+    return _load_mandatory_config_option(pytestconfig, ENV_VAR_KUBE_CONFIG)
+
+
+@pytest.fixture(scope="module")
+def test_extra_info(pytestconfig: Config) -> Dict[str, str]:
+    """Return an optional dict of variable names and values passed to the test using either
+    the `--extra-test-info` cmd line option or env vars prefixed with 'ATS_EXTRA_'."""
+    from_env = _filter_extra_info_from_mapping(os.environ)
+    if pytestconfig.getoption(CMD_VAR_TEST_EXTRA_INFO):
+        from_cmd = _parse_cmd_opt_extra_info(pytestconfig.getoption(CMD_VAR_TEST_EXTRA_INFO))
+        from_env.update(from_cmd)
+    return from_env
 
 
 @pytest.fixture(scope="module")

--- a/pytest_helm_charts/fixtures.py
+++ b/pytest_helm_charts/fixtures.py
@@ -92,19 +92,19 @@ def _parse_extra_info(info: str) -> Dict[str, str]:
 
 
 def _filter_extra_info_from_mapping(extra: Mapping[str, str]) -> Dict[str, str]:
-    return {k[len(ATS_EXTRA_PREFIX):].lower(): v for k, v in extra.items() if k.startswith(ATS_EXTRA_PREFIX)}
+    return {k[len(ATS_EXTRA_PREFIX) :].lower(): v for k, v in extra.items() if k.startswith(ATS_EXTRA_PREFIX)}
 
 
 @pytest.fixture(scope="module")
 def test_extra_info() -> Dict[str, str]:
     """Return an optional dict of variable names and values passed to the test using env vars prefixed with
-     'ATS_EXTRA_' env var."""
+    'ATS_EXTRA_' env var."""
     return _filter_extra_info_from_mapping(os.environ)
 
 
 @pytest.fixture(scope="module")
 def kube_cluster(
-        kube_config: str,
+    kube_config: str,
 ) -> Iterable[Cluster]:
     """Return a ready Cluster object, which can already be used in test to connect
     to the cluster. Specific implementation used to provide the cluster depends

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -1,3 +1,8 @@
+import os
+from pathlib import Path
+
+from _pytest.config.argparsing import Parser
+
 from pytest_helm_charts.fixtures import (  # noqa: F401
     chart_path,
     chart_version,
@@ -6,6 +11,14 @@ from pytest_helm_charts.fixtures import (  # noqa: F401
     kube_cluster,
     kube_config,
     values_file_path,
+    get_cmd_line_option_name_from_env_var,
+    CMD_VAR_TEST_EXTRA_INFO,
+    ENV_VAR_CHART_PATH,
+    ENV_VAR_CHART_VERSION,
+    ENV_VAR_CLUSTER_TYPE,
+    ENV_VAR_CLUSTER_VERSION,
+    ENV_VAR_KUBE_CONFIG,
+    ENV_VAR_APP_CONFIG_PATH,
 )
 from pytest_helm_charts.flux.fixtures import (  # noqa: F401
     flux_deployments,
@@ -35,3 +48,48 @@ from pytest_helm_charts.k8s.fixtures import (  # noqa: F401
     random_namespace,
     random_namespace_function_scope,
 )
+
+
+def _get_cmd_line_option_full_name(env_var_name: str) -> str:
+    cmd_name = get_cmd_line_option_name_from_env_var(env_var_name)
+    cmd_name.replace("_", "-")
+    return "--" + cmd_name
+
+
+def pytest_addoption(parser: Parser) -> None:
+    group = parser.getgroup("pytest-helm-charts")
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_CHART_PATH), action="store", help="The path to a helm chart under test."
+    )
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_CHART_VERSION),
+        action="store",
+        help="Override chart version for the chart under test.",
+    )
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_CLUSTER_TYPE),
+        action="store",
+        help="Pass information about cluster type being used for tests.",
+    )
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_CLUSTER_VERSION),
+        action="store",
+        help="Pass information about k8s version being used for tests.",
+    )
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_KUBE_CONFIG),
+        action="store",
+        default=os.path.join(str(Path.home()), ".kube", "config"),
+        help="The path to 'kube config' file.",
+    )
+    group.addoption(
+        _get_cmd_line_option_full_name(ENV_VAR_APP_CONFIG_PATH),
+        action="store",
+        help="Path to the values file used for testing the chart.",
+    )
+    group.addoption(
+        CMD_VAR_TEST_EXTRA_INFO,
+        action="store",
+        default="",
+        help="Pass any additional info about the test in the 'key1=val1,key2=val2' format",
+    )

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -42,29 +42,3 @@ from pytest_helm_charts.flux.fixtures import (  # noqa: F401
     helm_release_factory,
     helm_release_factory_function_scope,
 )
-
-
-def pytest_addoption(parser: Parser) -> None:
-    group = parser.getgroup("helm-charts")
-    group.addoption("--cluster-type", action="store", help="Pass information about cluster type being used for tests.")
-    group.addoption(
-        "--kube-config",
-        action="store",
-        default=os.path.join(str(Path.home()), ".kube", "config"),
-        help="The path to 'kube.config' file. Used when '--cluster-type existing' is used as well.",
-    )
-    group.addoption("--values-file", action="store", help="Path to the values file used for testing the chart.")
-    group.addoption("--chart-path", action="store", help="The path to a helm chart under test.")
-    group.addoption("--chart-version", action="store", help="Override chart version for the chart under test.")
-    group.addoption(
-        "--chart-extra-info",
-        action="store",
-        default="",
-        help="Pass any additional info about the chart in the 'key1=val1,key2=val2' format",
-    )
-    group.addoption(
-        "--test-extra-info",
-        action="store",
-        default="",
-        help="Pass any additional info about the test in the 'key1=val1,key2=val2' format",
-    )

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -1,24 +1,22 @@
-import os
-from pathlib import Path
-
-from _pytest.config.argparsing import Parser
-
-from pytest_helm_charts.k8s.fixtures import (  # noqa: F401
-    namespace_factory,
-    namespace_factory_function_scope,
-    random_namespace,
-    random_namespace_function_scope,
-)
 from pytest_helm_charts.fixtures import (  # noqa: F401
     chart_path,
     chart_version,
-    chart_extra_info,
     test_extra_info,
     cluster_type,
     kube_cluster,
     kube_config,
     values_file_path,
-    _existing_cluster_factory,
+)
+from pytest_helm_charts.flux.fixtures import (  # noqa: F401
+    flux_deployments,
+    kustomization_factory,
+    kustomization_factory_function_scope,
+    git_repository_factory,
+    git_repository_factory_function_scope,
+    helm_repository_factory,
+    helm_repository_factory_function_scope,
+    helm_release_factory,
+    helm_release_factory_function_scope,
 )
 from pytest_helm_charts.giantswarm_app_platform.apps.http_testing import (  # noqa: F401
     gatling_app_factory,
@@ -31,14 +29,9 @@ from pytest_helm_charts.giantswarm_app_platform.fixtures import (  # noqa: F401
     catalog_factory,
     catalog_factory_function_scope,
 )
-from pytest_helm_charts.flux.fixtures import (  # noqa: F401
-    flux_deployments,
-    kustomization_factory,
-    kustomization_factory_function_scope,
-    git_repository_factory,
-    git_repository_factory_function_scope,
-    helm_repository_factory,
-    helm_repository_factory_function_scope,
-    helm_release_factory,
-    helm_release_factory_function_scope,
+from pytest_helm_charts.k8s.fixtures import (  # noqa: F401
+    namespace_factory,
+    namespace_factory_function_scope,
+    random_namespace,
+    random_namespace_function_scope,
 )

--- a/pytest_helm_charts/plugin.py
+++ b/pytest_helm_charts/plugin.py
@@ -52,7 +52,7 @@ from pytest_helm_charts.k8s.fixtures import (  # noqa: F401
 
 def _get_cmd_line_option_full_name(env_var_name: str) -> str:
     cmd_name = get_cmd_line_option_name_from_env_var(env_var_name)
-    cmd_name.replace("_", "-")
+    cmd_name = cmd_name.replace("_", "-")
     return "--" + cmd_name
 
 
@@ -88,7 +88,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Path to the values file used for testing the chart.",
     )
     group.addoption(
-        CMD_VAR_TEST_EXTRA_INFO,
+        "--" + CMD_VAR_TEST_EXTRA_INFO,
         action="store",
         default="",
         help="Pass any additional info about the test in the 'key1=val1,key2=val2' format",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from pykube import HTTPClient
 from pytest_mock import MockFixture
 
 from pytest_helm_charts.clusters import Cluster
-from pytest_helm_charts.fixtures import ConfigFactoryFunction
 
 pytest_plugins = ["pytester"]
 
@@ -30,7 +29,6 @@ class MockCluster(Cluster):
 def kube_cluster(
     cluster_type: str,
     session_mocker: MockFixture,
-    _existing_cluster_factory: ConfigFactoryFunction,
 ) -> Cluster:
     cluster = MockCluster(session_mocker)
     cluster.create()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -8,11 +8,15 @@ from pytest_mock import MockFixture
 
 def run_pytest(pytester: Pytester, mocker: MockFixture, *args: Any) -> RunResult:
     mocker.patch("pytest_helm_charts.fixtures.ExistingCluster", autospec=True)
-    mocker.patch.dict(os.environ, {
-        "KUBECONFIG": "/tmp/kat_test/kube.config",
-        "ATS_CLUSTER_TYPE": "existing",
-        "ATS_EXTRA_EXTERNAL_CLUSTER_TYPE": "kind",
-    }, clear=True)
+    mocker.patch.dict(
+        os.environ,
+        {
+            "KUBECONFIG": "/tmp/kat_test/kube.config",  # nosec: this is not used, mock value only
+            "ATS_CLUSTER_TYPE": "existing",
+            "ATS_EXTRA_EXTERNAL_CLUSTER_TYPE": "kind",
+        },
+        clear=True,
+    )
     result = pytester.runpytest(
         "--log-cli-level",
         "debug",

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 from _pytest.pytester import RunResult
@@ -7,14 +8,14 @@ from pytest_mock import MockFixture
 
 def run_pytest(pytester: Pytester, mocker: MockFixture, *args: Any) -> RunResult:
     mocker.patch("pytest_helm_charts.fixtures.ExistingCluster", autospec=True)
+    mocker.patch.dict(os.environ, {
+        "KUBECONFIG": "/tmp/kat_test/kube.config",
+        "ATS_CLUSTER_TYPE": "existing",
+        "ATS_EXTRA_EXTERNAL_CLUSTER_TYPE": "kind",
+    }, clear=True)
     result = pytester.runpytest(
-        "--cluster-type",
-        "existing",
         "--log-cli-level",
         "debug",
-        "--kube-config",
-        "/tmp/kat_test/kube.config",  # nosec
-        '--chart-extra-info="key1=val1,external_cluster_type=kind"',
         "-v",
         *args,
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,17 +5,15 @@ import pytest
 from pytest_helm_charts.fixtures import _filter_extra_info_from_mapping, ATS_EXTRA_PREFIX
 
 
-@pytest.mark.parametrize(["env", "expected"],
-                         [
-                             ({}, {}),
-                             ({"t": "a"}, {}),
-                             ({ATS_EXTRA_PREFIX+"TEST": "abc"}, {"test": "abc"}),
-                             ({
-                                 ATS_EXTRA_PREFIX+"CHUCK": "Norris",
-                                 "Bruce": "Lee"
-                             },
-                              {"chuck": "Norris"})
-                         ],
-                         ids=["empty", "none matching", "single and matching", "some matching"])
+@pytest.mark.parametrize(
+    ["env", "expected"],
+    [
+        ({}, {}),
+        ({"t": "a"}, {}),
+        ({ATS_EXTRA_PREFIX + "TEST": "abc"}, {"test": "abc"}),
+        ({ATS_EXTRA_PREFIX + "CHUCK": "Norris", "Bruce": "Lee"}, {"chuck": "Norris"}),
+    ],
+    ids=["empty", "none matching", "single and matching", "some matching"],
+)
 def test_test_extra_info(env: Mapping[str, str], expected: Dict[str, str]) -> None:
     assert _filter_extra_info_from_mapping(env) == expected

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,7 @@ from typing import Dict, Mapping
 
 import pytest
 
-from pytest_helm_charts.fixtures import _filter_extra_info_from_mapping, ATS_EXTRA_PREFIX
+from pytest_helm_charts.fixtures import _filter_extra_info_from_mapping, ENV_VAR_ATS_EXTRA_PREFIX
 
 
 @pytest.mark.parametrize(
@@ -10,8 +10,8 @@ from pytest_helm_charts.fixtures import _filter_extra_info_from_mapping, ATS_EXT
     [
         ({}, {}),
         ({"t": "a"}, {}),
-        ({ATS_EXTRA_PREFIX + "TEST": "abc"}, {"test": "abc"}),
-        ({ATS_EXTRA_PREFIX + "CHUCK": "Norris", "Bruce": "Lee"}, {"chuck": "Norris"}),
+        ({ENV_VAR_ATS_EXTRA_PREFIX + "TEST": "abc"}, {"test": "abc"}),
+        ({ENV_VAR_ATS_EXTRA_PREFIX + "CHUCK": "Norris", "Bruce": "Lee"}, {"chuck": "Norris"}),
     ],
     ids=["empty", "none matching", "single and matching", "some matching"],
 )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,14 +1,21 @@
-# noinspection PyProtectedMember
-from pytest_helm_charts.fixtures import _parse_extra_info  # noqa: F401
+from typing import Dict, Mapping
+
+import pytest
+
+from pytest_helm_charts.fixtures import _filter_extra_info_from_mapping, ATS_EXTRA_PREFIX
 
 
-def test_parse_chart_extra_info() -> None:
-    res = _parse_extra_info("key1=val1,external_cluster_type=kind")
-    assert len(res) == 2
-    assert "key1" in res and res["key1"] == "val1"
-    assert "external_cluster_type" in res and res["external_cluster_type"] == "kind"
-
-
-def test_parse_chart_no_extra_info() -> None:
-    res = _parse_extra_info("")
-    assert len(res) == 0
+@pytest.mark.parametrize(["env", "expected"],
+                         [
+                             ({}, {}),
+                             ({"t": "a"}, {}),
+                             ({ATS_EXTRA_PREFIX+"TEST": "abc"}, {"test": "abc"}),
+                             ({
+                                 ATS_EXTRA_PREFIX+"CHUCK": "Norris",
+                                 "Bruce": "Lee"
+                             },
+                              {"chuck": "Norris"})
+                         ],
+                         ids=["empty", "none matching", "single and matching", "some matching"])
+def test_test_extra_info(env: Mapping[str, str], expected: Dict[str, str]) -> None:
+    assert _filter_extra_info_from_mapping(env) == expected


### PR DESCRIPTION
This is a breaking change for a 1.0.x incoming release.

This PR introduces a breaking change of loading cluster and chart configuration options from environment variables and not command line options. It has 2 benefits:
- making variables optional allows for easier usage of this plugin when not being invoked by `ats`
- using env variables makes it possible to use the same test run configuration code for both python and go in `ats` (go test doesn't support command line options)