### PR TITLE
Delete extra CODEOWNERS file in .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* piontec @giantswarm/team-halo-engineers


### PR DESCRIPTION
This file is invalid. I'm assuming it's no longer needed, so deleting it.