### PR TITLE
Fix _deployment_running method to check for deployment unavailableReplicas to be 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- fixed
+  - the `_deployment_running` method was missing a check for `unavailableReplicas`
+
 ## [1.2.0] - 2024-02-06
 
 - added:

--- a/pytest_helm_charts/k8s/deployment.py
+++ b/pytest_helm_charts/k8s/deployment.py
@@ -11,9 +11,11 @@ def _deployment_running(deploy: Deployment) -> bool:
         and "availableReplicas" in deploy.obj["status"]
         and "observedGeneration" in deploy.obj["status"]
         and "updatedReplicas" in deploy.obj["status"]
+        and "unavailableReplicas" in deploy.obj["status"]
         and int(deploy.obj["status"]["observedGeneration"]) >= int(deploy.obj["metadata"]["generation"])
         and deploy.replicas == int(deploy.obj["status"]["updatedReplicas"])
         and deploy.replicas == int(deploy.obj["status"]["availableReplicas"])
+        and 0 == int(deploy.obj["status"]["unavailableReplicas"])
     )
     return complete
 


### PR DESCRIPTION
This PR fixes an issue with the `_deployment_running` method which was not checking for the `unavailableReplicas` field of the deployment object to be 0. This caused the method to return `True` in cases the deployment was not fully running.

### Problem observed

observability-operator on version `8bd93f1` has a bug preventing it to start. But ats test did ran correctly.

- observability-operator ats test: https://github.com/giantswarm/observability-operator/blob/8bd93f14f494795c71b2c7460ca34d9119ab0627/tests/ats/test_olly_op.py#L30
- CI ran successfully: https://app.circleci.com/pipelines/github/giantswarm/observability-operator/901/workflows/9b9ba0c7-ff4f-48b2-bae1-bd6828476c89/jobs/3525
- Manually read pod logs from ats container:

```
root@ip-10-0-81-18:/ats/workdir# k logs -n monitoring observability-operator-d5c5c7f87-w9mmd
/manager flag redefined: monitoring-agent
panic: /manager flag redefined: monitoring-agent

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc00016c000, {0x1e8e690, 0x2d72cb0}, {0x1be11e6, 0x10}, {0xc0004dce00, 0x3a})
        /usr/local/go/src/flag/flag.go:1028 +0x37d
flag.StringVar(...)
        /usr/local/go/src/flag/flag.go:885
main.main()
        /workspace/main.go:124 +0x57c
```

- Manually read deployment status from ats container:

```
root@ip-10-0-81-18:/ats/workdir# k get -n monitoring deployment observability-operator -oyaml
...
replicas: 1
unavailableReplicas: 1
updatedReplicas: 1

### Expected behavior

ats test should fail when the deployment have some unavailable replicas.